### PR TITLE
empty line before values adds an untitled color to palette in Gimp

### DIFF
--- a/docs/asset/download/open-color_1.4.0.gpl
+++ b/docs/asset/download/open-color_1.4.0.gpl
@@ -2,7 +2,6 @@ GIMP Palette
 Name: Open Color Palette 1.4.0
 Columns: 0
 #
-
 248 249 250        gray0
 241 243 245        gray1
 233 236 239        gray2

--- a/templates/open-color.inkscape.hbs
+++ b/templates/open-color.inkscape.hbs
@@ -2,7 +2,6 @@ GIMP Palette
 Name: Open Color Palette {{version}}
 Columns: 0
 #
-
 {{#each colors as |color|}}
     {{#each color.hex as |hex|~}}
         {{#with (hex2rgb hex) as |rgb|~}}


### PR DESCRIPTION
current gimp
![gimpblank](https://cloud.githubusercontent.com/assets/3585901/20039889/8ace0636-a41a-11e6-85c6-6b5ecde5cdba.png)

empty line removed
![gimpfix](https://cloud.githubusercontent.com/assets/3585901/20039928/6478158e-a41b-11e6-9de0-cd8d6134b4eb.png)

_This has no effect on Inkscape._