### PR TITLE
add version to bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "open-color",
+  "version": "1.4.1",
   "description": "Open color scheme for web UI",
    "main": [
     "open-color.scss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-color",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Open color scheme for web UI",
   "main": "open-color.scss",
   "scripts": {


### PR DESCRIPTION
I update the version number too, to allow a new release (tag)

The last release (1.4.0) dont contains the bower.json recently accepted in the PR https://github.com/yeun/open-color/pull/48

