### PR TITLE
Be able to copy hex values without hash prefix

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,8 +17,8 @@ layout: default
             <div class="color-chip-bg bg-{{ color }}-{{ i }}">
             </div>
             <div class="color-name">{{ color }} {{ i }}</div>
-            <input class="color-var" type="text"  onclick="this.focus();this.select()"  readonly="" value="$oc-{{ color }}-{{ i }}">
-            <input class="color-hex" type="text"  onclick="this.focus();this.select()"  readonly="" value="{{ site[idx][i] }}">
+            <input class="color-var" type="text" onclick="this.focus();this.select()" readonly value="$oc-{{ color }}-{{ i }}">
+            <input class="color-hex" type="text" readonly value="{{ site[idx][i] }}">
           </div>
           {% endfor %}
         </div>


### PR DESCRIPTION
_(This is an attempt to tackle https://github.com/yeun/open-color/issues/50)_

Following the issue linked above, I removed the `onclick` attribute of the second input element containing the hexadecimal value of the color.

**Before:** Clicking the hex value resulted in focussing and selecting the complete value including the `#` prefix.

**Now:** A click does not yield a special functionality anymore. The hex value (without the `#`) can be selected by double-clicking. A triple-click will select the hex value including the `#`.

This change introduces a inconsistency. Clicking on the variable input above will still focus and select the complete variable. The behavior for the hex input element however will be different.

One way to remove this inconsistency would be removing the `onclick` attribute for the variable input element as well. However I think this would be a step backwards because copying the complete variable should be desirable in most cases.

The other way would be using JavaScript to select the hex value with more fine-grained control. For example, clicking once would select only the hex value without the prefix `#`, clicking twice would select the complete value with the prefix.

I prefer the solution suggested in the form of the pull request itself because it is simple and results in no big problems as far as I’m concerned.