### PR TITLE
Add meta description and consistent title name

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -8,13 +8,14 @@
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ site.baseurl }}/asset/favicon/apple-touch-icon-152x152.png" />
     <link rel="icon" type="image/png" href="{{ site.baseurl }}/asset/favicon/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="{{ site.baseurl }}/asset/favicon/favicon-16x16.png" sizes="16x16" />
-    <meta name="application-name" content="Open color"/>
+    <meta name="description" content="Color scheme for UI design" />
+    <meta name="application-name" content="Open Color"/>
     <meta name="msapplication-TileColor" content="#FFFFFF" />
     <meta name="msapplication-TileImage" content="{{ site.baseurl }}/asset/favicon/mstile-144x144.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@_heeyeun">
     <meta name="twitter:creator" content="@_heeyeun" />
-    <meta property="og:title" content="Open color" />
+    <meta property="og:title" content="Open Color" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://yeun.github.io/open-color/" />
     <meta property="og:description" content="Color scheme for UI design" />


### PR DESCRIPTION
I was Googling Open Color to find the URL and I found this:

![image](https://cloud.githubusercontent.com/assets/5153378/22175193/4382ae74-e044-11e6-93b6-caa87c20f4cd.png)

So I've added a `<meta name="description">` to correct this.

Also I've made the title name references to be consistent. The change is basically "Open color" to "Open Color".