### PR TITLE
use key files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "1.4.2",
   "description": "Open color scheme for web UI",
   "main": "open-color.scss",
+  "files": [
+    "open-color.css",
+    "open-color.json",
+    "open-color.less",
+    "open-color.styl"
+  ],
   "scripts": {
     "test": "",
     "compile-templates": "node compile-templates.js"


### PR DESCRIPTION
hey guys!!

this PR is an suggestion, in package.json you define only a file for key `main`.
in package docs, I see the key `files`, used to define more files to be included on module downloaded, and reference to files.

this is useful to automated bundles that make use of this key, and to reduce size of module in disk, the other files and directories dont be downloaded (except package.json, main, licensce, etc), [more here](https://docs.npmjs.com/files/package.json#files) 