### PR TITLE
Add support for generating a typescript definition file (fixed #74)

### DIFF
--- a/compile-templates.js
+++ b/compile-templates.js
@@ -40,3 +40,6 @@ craftLibraryBuilder.build(
 
 templatedBuilder.build('open-color.oco',
     [path.join(__dirname, 'open-color.oco')]);
+
+templatedBuilder.build('open-color.d.ts',
+    [path.join(__dirname, 'open-color.d.ts')]);

--- a/open-color.d.ts
+++ b/open-color.d.ts
@@ -1,0 +1,31 @@
+//
+//
+//  𝗖 𝗢 𝗟 𝗢 𝗥
+//  v 1.5.1
+//
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+declare module 'open-color' {
+    type Color = string;
+
+    interface OpenColor {
+        white: Color
+        black: Color
+
+        gray: Color[]
+        red: Color[]
+        pink: Color[]
+        grape: Color[]
+        violet: Color[]
+        indigo: Color[]
+        blue: Color[]
+        cyan: Color[]
+        teal: Color[]
+        green: Color[]
+        lime: Color[]
+        yellow: Color[]
+        orange: Color[]
+    }
+
+    const OpenColor: OpenColor;
+    export default OpenColor;
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "open-color.styl"
   ],
   "scripts": {
-    "test": "",
+    "test": "npm run test-typescript",
+    "test-typescript": "tsc open-color.d.ts tests/typescript.ts --noEmit",
     "compile-templates": "node compile-templates.js"
   },
   "repository": {
@@ -34,9 +35,11 @@
   },
   "homepage": "https://github.com/yeun/open-color",
   "devDependencies": {
+    "archiver": "^1.3.0",
     "ase-utils": "^0.1.1",
     "handlebars": "^4.0.5",
-    "uuid": "^3.0.1",
-    "archiver": "^1.3.0"
-  }
+    "typescript": "^2.5.2",
+    "uuid": "^3.0.1"
+  },
+  "types": "./open-color.d.ts"
 }

--- a/templates/open-color.d.ts.hbs
+++ b/templates/open-color.d.ts.hbs
@@ -1,0 +1,22 @@
+//
+//
+//  𝗖 𝗢 𝗟 𝗢 𝗥
+//  v {{version}}
+//
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+declare module 'open-color' {
+    type Color = string;
+
+    interface OpenColor {
+    {{#each general as |color|}}
+        {{color.name}}: Color
+    {{/each}}
+
+    {{#each colors as |color|}}
+        {{color.name}}: Color[]
+    {{/each}}
+    }
+
+    const OpenColor: OpenColor;
+    export default OpenColor;
+}

--- a/tests/typescript.ts
+++ b/tests/typescript.ts
@@ -1,0 +1,9 @@
+import OpenColor from "open-color";
+
+// black is regular string field
+OpenColor.black.substring(1);
+
+// red is array string field
+OpenColor.red.forEach(hex => {
+    console.log(hex.substring(1));
+});


### PR DESCRIPTION
This also adds a test that the generated typescript definitions compile.
Maybe we should add `npm t` to the travis.yml to let travis run these "tests".

This is a template build from the work provided by @Rokt33r in #74 