### PR TITLE
Include `open-color.d.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "open-color.css",
     "open-color.scss",
     "open-color.less",
-    "open-color.styl"
+    "open-color.styl",
+    "open-color.d.ts"
   ],
   "scripts": {
     "test": "npm run test-typescript",


### PR DESCRIPTION
The type definition file is missing in installed npm module.
<img width="287" alt="screen shot 2019-01-05 at 12 53 40" src="https://user-images.githubusercontent.com/5865853/50720048-f3c8f000-10e8-11e9-90f7-7fafa5a35ce0.png">
