### PR TITLE
Add Link to Figma Library Under "Downloads"

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -82,6 +82,7 @@
                 <li><a class="nav-menu" href="{{ site.baseurl }}/asset/download/open-color_{{ site.oc-version }}.sketchpalette" download>Sketch palette</a></li>
                 <li><a class="nav-menu" href="{{ site.baseurl }}/asset/download/open-color_{{ site.oc-version }}.gpl" download>Inkscape swatches</a></li>
                 <li><a class="nav-menu" href="{{ site.baseurl }}/asset/download/open-color_{{ site.oc-version }}.clr" download>Mac OS palette</a></li>
+                <li><a class="nav-menu" href="https://www.figma.com/file/Qj5TvDTLjOBynKQT6995eToz/Open-Color">Figma library ↗️</a></li>
               </ul>
             </li>
             <li class="nav-menus-group"><a class="menus-title menus-github" href="https://github.com/yeun/open-color">GitHub</a></li>


### PR DESCRIPTION
* Link to publicly accessible Figma file that users can publish or copy
into their own team envrionment

* Add a unicode arrow to the dropdown entry for figma to indicate it
is an external link rather than a download

Fixes https://github.com/yeun/open-color/issues/96