### PR TITLE
Correct type definition for CJS

### DIFF
--- a/open-color.d.ts
+++ b/open-color.d.ts
@@ -27,5 +27,5 @@ declare module 'open-color' {
     }
 
     const OpenColor: OpenColor;
-    export default OpenColor;
+    export = OpenColor;
 }

--- a/tests/typescript.ts
+++ b/tests/typescript.ts
@@ -1,4 +1,4 @@
-import OpenColor from "open-color";
+import OpenColor = require("open-color");
 
 // black is regular string field
 OpenColor.black.substring(1);


### PR DESCRIPTION
The current type definition won't work with CommonJS(cjs) import style, `require('...')` because we're lying to Typescript that we're exporting it as `default`. So typescript would expect that `require('open-color')` should look like `{default: {white: ..., black: ....}}`, not `{white: ..., black: ....}`. Yeah but it still working in some conditions like using esm with `esModuleInterop` prop. If `esModuleInterop` is true, typescript compiler mitigates the difference between esm and cjs styles. Otherwise, adopters will confront the below errors.

```ts
// cjs style importing
import oc = require('open-color') // Equivalent to `const oc = require('open-color')`

// `error TS2339: Property 'white' does not exist on type 'typeof 'open-color'` will be thrown while compiling.
oc.white

// `TypeError: Cannot read property 'default' of undefined` will be thrown on runtime while passing compiling
oc.default.white
```

FYI, I submit a similar problem. https://github.com/unifiedjs/unified/issues/56
