### PR TITLE
Add support for generating Dart code

### DIFF
--- a/compile-templates.js
+++ b/compile-templates.js
@@ -29,6 +29,8 @@ templatedBuilder.build('open-color.svg',
     [path.join(__dirname, 'docs', 'asset', 'images', 'open-color.svg')]);
 templatedBuilder.build('open-color.tex',
     [path.join(__dirname, 'open-color.tex')]);
+templatedBuilder.build('open_color.dart',
+    [path.join(__dirname, 'open_color.dart')]);
 
 templatedBuilder.build('open-color.sketchpalette',
     [path.join(__dirname, 'docs', 'asset', 'download', `open-color_${pkg.version}.sketchpalette`)]);

--- a/open_color.dart
+++ b/open_color.dart
@@ -1,0 +1,213 @@
+/*
+*
+* 𝗖 𝗢 𝗟 𝗢 𝗥
+* v 1.7.0
+*
+* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+import 'dart:ui';
+
+class OpenColor {
+
+  /* General
+   * ─────────────────────────────────── */
+
+  static const white = Color.fromARGB(255, 255, 255, 255);
+  static const black = Color.fromARGB(255, 0, 0, 0);
+
+
+  /* Gray
+   * ─────────────────────────────────── */
+
+  static const gray0 = Color.fromARGB(255, 248, 249, 250);
+  static const gray1 = Color.fromARGB(255, 241, 243, 245);
+  static const gray2 = Color.fromARGB(255, 233, 236, 239);
+  static const gray3 = Color.fromARGB(255, 222, 226, 230);
+  static const gray4 = Color.fromARGB(255, 206, 212, 218);
+  static const gray5 = Color.fromARGB(255, 173, 181, 189);
+  static const gray6 = Color.fromARGB(255, 134, 142, 150);
+  static const gray7 = Color.fromARGB(255, 73, 80, 87);
+  static const gray8 = Color.fromARGB(255, 52, 58, 64);
+  static const gray9 = Color.fromARGB(255, 33, 37, 41);
+
+
+  /* Red
+   * ─────────────────────────────────── */
+
+  static const red0 = Color.fromARGB(255, 255, 245, 245);
+  static const red1 = Color.fromARGB(255, 255, 227, 227);
+  static const red2 = Color.fromARGB(255, 255, 201, 201);
+  static const red3 = Color.fromARGB(255, 255, 168, 168);
+  static const red4 = Color.fromARGB(255, 255, 135, 135);
+  static const red5 = Color.fromARGB(255, 255, 107, 107);
+  static const red6 = Color.fromARGB(255, 250, 82, 82);
+  static const red7 = Color.fromARGB(255, 240, 62, 62);
+  static const red8 = Color.fromARGB(255, 224, 49, 49);
+  static const red9 = Color.fromARGB(255, 201, 42, 42);
+
+
+  /* Pink
+   * ─────────────────────────────────── */
+
+  static const pink0 = Color.fromARGB(255, 255, 240, 246);
+  static const pink1 = Color.fromARGB(255, 255, 222, 235);
+  static const pink2 = Color.fromARGB(255, 252, 194, 215);
+  static const pink3 = Color.fromARGB(255, 250, 162, 193);
+  static const pink4 = Color.fromARGB(255, 247, 131, 172);
+  static const pink5 = Color.fromARGB(255, 240, 101, 149);
+  static const pink6 = Color.fromARGB(255, 230, 73, 128);
+  static const pink7 = Color.fromARGB(255, 214, 51, 108);
+  static const pink8 = Color.fromARGB(255, 194, 37, 92);
+  static const pink9 = Color.fromARGB(255, 166, 30, 77);
+
+
+  /* Grape
+   * ─────────────────────────────────── */
+
+  static const grape0 = Color.fromARGB(255, 248, 240, 252);
+  static const grape1 = Color.fromARGB(255, 243, 217, 250);
+  static const grape2 = Color.fromARGB(255, 238, 190, 250);
+  static const grape3 = Color.fromARGB(255, 229, 153, 247);
+  static const grape4 = Color.fromARGB(255, 218, 119, 242);
+  static const grape5 = Color.fromARGB(255, 204, 93, 232);
+  static const grape6 = Color.fromARGB(255, 190, 75, 219);
+  static const grape7 = Color.fromARGB(255, 174, 62, 201);
+  static const grape8 = Color.fromARGB(255, 156, 54, 181);
+  static const grape9 = Color.fromARGB(255, 134, 46, 156);
+
+
+  /* Violet
+   * ─────────────────────────────────── */
+
+  static const violet0 = Color.fromARGB(255, 243, 240, 255);
+  static const violet1 = Color.fromARGB(255, 229, 219, 255);
+  static const violet2 = Color.fromARGB(255, 208, 191, 255);
+  static const violet3 = Color.fromARGB(255, 177, 151, 252);
+  static const violet4 = Color.fromARGB(255, 151, 117, 250);
+  static const violet5 = Color.fromARGB(255, 132, 94, 247);
+  static const violet6 = Color.fromARGB(255, 121, 80, 242);
+  static const violet7 = Color.fromARGB(255, 112, 72, 232);
+  static const violet8 = Color.fromARGB(255, 103, 65, 217);
+  static const violet9 = Color.fromARGB(255, 95, 61, 196);
+
+
+  /* Indigo
+   * ─────────────────────────────────── */
+
+  static const indigo0 = Color.fromARGB(255, 237, 242, 255);
+  static const indigo1 = Color.fromARGB(255, 219, 228, 255);
+  static const indigo2 = Color.fromARGB(255, 186, 200, 255);
+  static const indigo3 = Color.fromARGB(255, 145, 167, 255);
+  static const indigo4 = Color.fromARGB(255, 116, 143, 252);
+  static const indigo5 = Color.fromARGB(255, 92, 124, 250);
+  static const indigo6 = Color.fromARGB(255, 76, 110, 245);
+  static const indigo7 = Color.fromARGB(255, 66, 99, 235);
+  static const indigo8 = Color.fromARGB(255, 59, 91, 219);
+  static const indigo9 = Color.fromARGB(255, 54, 79, 199);
+
+
+  /* Blue
+   * ─────────────────────────────────── */
+
+  static const blue0 = Color.fromARGB(255, 231, 245, 255);
+  static const blue1 = Color.fromARGB(255, 208, 235, 255);
+  static const blue2 = Color.fromARGB(255, 165, 216, 255);
+  static const blue3 = Color.fromARGB(255, 116, 192, 252);
+  static const blue4 = Color.fromARGB(255, 77, 171, 247);
+  static const blue5 = Color.fromARGB(255, 51, 154, 240);
+  static const blue6 = Color.fromARGB(255, 34, 139, 230);
+  static const blue7 = Color.fromARGB(255, 28, 126, 214);
+  static const blue8 = Color.fromARGB(255, 25, 113, 194);
+  static const blue9 = Color.fromARGB(255, 24, 100, 171);
+
+
+  /* Cyan
+   * ─────────────────────────────────── */
+
+  static const cyan0 = Color.fromARGB(255, 227, 250, 252);
+  static const cyan1 = Color.fromARGB(255, 197, 246, 250);
+  static const cyan2 = Color.fromARGB(255, 153, 233, 242);
+  static const cyan3 = Color.fromARGB(255, 102, 217, 232);
+  static const cyan4 = Color.fromARGB(255, 59, 201, 219);
+  static const cyan5 = Color.fromARGB(255, 34, 184, 207);
+  static const cyan6 = Color.fromARGB(255, 21, 170, 191);
+  static const cyan7 = Color.fromARGB(255, 16, 152, 173);
+  static const cyan8 = Color.fromARGB(255, 12, 133, 153);
+  static const cyan9 = Color.fromARGB(255, 11, 114, 133);
+
+
+  /* Teal
+   * ─────────────────────────────────── */
+
+  static const teal0 = Color.fromARGB(255, 230, 252, 245);
+  static const teal1 = Color.fromARGB(255, 195, 250, 232);
+  static const teal2 = Color.fromARGB(255, 150, 242, 215);
+  static const teal3 = Color.fromARGB(255, 99, 230, 190);
+  static const teal4 = Color.fromARGB(255, 56, 217, 169);
+  static const teal5 = Color.fromARGB(255, 32, 201, 151);
+  static const teal6 = Color.fromARGB(255, 18, 184, 134);
+  static const teal7 = Color.fromARGB(255, 12, 166, 120);
+  static const teal8 = Color.fromARGB(255, 9, 146, 104);
+  static const teal9 = Color.fromARGB(255, 8, 127, 91);
+
+
+  /* Green
+   * ─────────────────────────────────── */
+
+  static const green0 = Color.fromARGB(255, 235, 251, 238);
+  static const green1 = Color.fromARGB(255, 211, 249, 216);
+  static const green2 = Color.fromARGB(255, 178, 242, 187);
+  static const green3 = Color.fromARGB(255, 140, 233, 154);
+  static const green4 = Color.fromARGB(255, 105, 219, 124);
+  static const green5 = Color.fromARGB(255, 81, 207, 102);
+  static const green6 = Color.fromARGB(255, 64, 192, 87);
+  static const green7 = Color.fromARGB(255, 55, 178, 77);
+  static const green8 = Color.fromARGB(255, 47, 158, 68);
+  static const green9 = Color.fromARGB(255, 43, 138, 62);
+
+
+  /* Lime
+   * ─────────────────────────────────── */
+
+  static const lime0 = Color.fromARGB(255, 244, 252, 227);
+  static const lime1 = Color.fromARGB(255, 233, 250, 200);
+  static const lime2 = Color.fromARGB(255, 216, 245, 162);
+  static const lime3 = Color.fromARGB(255, 192, 235, 117);
+  static const lime4 = Color.fromARGB(255, 169, 227, 75);
+  static const lime5 = Color.fromARGB(255, 148, 216, 45);
+  static const lime6 = Color.fromARGB(255, 130, 201, 30);
+  static const lime7 = Color.fromARGB(255, 116, 184, 22);
+  static const lime8 = Color.fromARGB(255, 102, 168, 15);
+  static const lime9 = Color.fromARGB(255, 92, 148, 13);
+
+
+  /* Yellow
+   * ─────────────────────────────────── */
+
+  static const yellow0 = Color.fromARGB(255, 255, 249, 219);
+  static const yellow1 = Color.fromARGB(255, 255, 243, 191);
+  static const yellow2 = Color.fromARGB(255, 255, 236, 153);
+  static const yellow3 = Color.fromARGB(255, 255, 224, 102);
+  static const yellow4 = Color.fromARGB(255, 255, 212, 59);
+  static const yellow5 = Color.fromARGB(255, 252, 196, 25);
+  static const yellow6 = Color.fromARGB(255, 250, 176, 5);
+  static const yellow7 = Color.fromARGB(255, 245, 159, 0);
+  static const yellow8 = Color.fromARGB(255, 240, 140, 0);
+  static const yellow9 = Color.fromARGB(255, 230, 119, 0);
+
+
+  /* Orange
+   * ─────────────────────────────────── */
+
+  static const orange0 = Color.fromARGB(255, 255, 244, 230);
+  static const orange1 = Color.fromARGB(255, 255, 232, 204);
+  static const orange2 = Color.fromARGB(255, 255, 216, 168);
+  static const orange3 = Color.fromARGB(255, 255, 192, 120);
+  static const orange4 = Color.fromARGB(255, 255, 169, 77);
+  static const orange5 = Color.fromARGB(255, 255, 146, 43);
+  static const orange6 = Color.fromARGB(255, 253, 126, 20);
+  static const orange7 = Color.fromARGB(255, 247, 103, 7);
+  static const orange8 = Color.fromARGB(255, 232, 89, 12);
+  static const orange9 = Color.fromARGB(255, 217, 72, 15);
+
+}

--- a/templates/open_color.dart.hbs
+++ b/templates/open_color.dart.hbs
@@ -1,0 +1,33 @@
+/*
+*
+* 𝗖 𝗢 𝗟 𝗢 𝗥
+* v {{version}}
+*
+* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+import 'dart:ui';
+
+class OpenColor {
+
+  /* General
+   * ─────────────────────────────────── */
+
+{{#each general as |color|}}
+{{#with (hex2rgb color.hex) as |rgb|}}
+  static const {{color.name}} = Color.fromARGB(255, {{rgb.r}}, {{rgb.g}}, {{rgb.b}});
+{{/with}}
+{{/each}}
+{{#each colors as |color|}}
+
+
+  /* {{capitalize color.name}}
+   * ─────────────────────────────────── */
+
+{{#each color.hex as |hex index|}}
+{{#with (hex2rgb hex) as |rgb|}}
+  static const {{color.name}}{{index}} = Color.fromARGB(255, {{rgb.r}}, {{rgb.g}}, {{rgb.b}});
+{{/with}}
+{{/each}}
+{{/each}}
+
+}


### PR DESCRIPTION
Adds template support for building Dart code. Generates the color scheme as a single dart class with static const color names. This approach is how the Flutter team [define colours for their Material swatches](https://api.flutter.dev/flutter/material/Colors-class.html).

There is additional work to build a dart package that can be published to pub.dev. Not sure whether you would want that in this repository, or if you are interested in maintaining a dart package, but I'm happy to add the project structure and help with publishing.