### PR TITLE
Add Emacs Lisp bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,4 @@ a:active {
 
 - Julia : [OpenColor.jl](https://github.com/appleparan/OpenColor.jl)
 - Go : [opencolor](https://pkg.go.dev/github.com/jsynacek/go-open-color/opencolor)
+- Emacs Lisp: [open-color.el](https://github.com/a13/open-color.el)


### PR DESCRIPTION
Hi, thank you for the project!
I've ported (actually wrote a script to generate the code using the provided JSON file) Open Color to Emacs Lisp to use inside Emacs, mostly for writing color themes. 
Unfortunately, I don't have time to rewrite the whole stuff in Handlebars as for now, but since there are already 3rd party ports here, adding mine can be useful too.